### PR TITLE
genserver handle_call

### DIFF
--- a/api/lib/circles/tracker/tracker.ex
+++ b/api/lib/circles/tracker/tracker.ex
@@ -11,7 +11,7 @@ defmodule Circles.Tracker do
   end
 
   def insert(%User{} = user) do
-    :ets.insert(@tab, {user.id, user})
+    GenServer.call(__MODULE__, {:insert, {user.id, user}})
   end
 
   def list do
@@ -24,5 +24,11 @@ defmodule Circles.Tracker do
                                                  write_concurrency: true])
 
     {:ok, %{}}
+  end
+
+  def handle_call({:insert, data}, _from, _state) do
+    result = :ets.insert(@tab, data)
+
+    {:reply, result, %{}}
   end
 end


### PR DESCRIPTION
Something like this is what I meant. From the main thread you call `Tracker.insert(data)` and it sends a message with the data to the genserver to then insert the data into the ets table. Previously the ets table was just being used from the main thread. Now the work is done by the genserver. I manually ran this with `iex -S mix`.